### PR TITLE
Add an option to try to fix misaligned notes when pasting sv

### DIFF
--- a/src/menus/edit/copyPaste.lua
+++ b/src/menus/edit/copyPaste.lua
@@ -18,10 +18,15 @@ function copyNPasteMenu()
         button("Clear copied items", ACTION_BUTTON_SIZE, clearCopiedItems, menuVars)
     end
 
-    saveVariables("copyMenu", menuVars)
-
-    if copiedItemCount == 0 then return end
+    if copiedItemCount == 0 then
+        saveVariables("copyMenu", menuVars)
+        return
+    end
 
     addSeparator()
+
+    _, menuVars.tryAlign = imgui.Checkbox("Try to fix misalignments", menuVars.tryAlign)
+    saveVariables("copyMenu", menuVars)
+
     simpleActionMenu("Paste items at selected notes", 1, pasteItems, menuVars)
 end

--- a/src/menus/settings/defaultProperties.lua
+++ b/src/menus/settings/defaultProperties.lua
@@ -117,6 +117,11 @@ function showDefaultPropertiesSettings()
         imgui.SameLine(0, SAMELINE_SPACING + 3.5)
         _, menuVars.copyTable[4] = imgui.Checkbox("Copy Bookmarks", menuVars.copyTable[4])
 
+        _, menuVars.tryAlign = imgui.Checkbox("Try to fix misalignments", menuVars.tryAlign)
+        imgui.PushItemWidth(100)
+        _, menuVars.alignWindow = imgui.SliderInt("Alignment window (ms)", menuVars.alignWindow, 1, 10)
+        imgui.PopItemWidth()
+
         saveMenuPropertiesButton(menuVars, "copy")
         saveVariables("copyPropertyMenu", menuVars)
     end

--- a/src/vars/menu.lua
+++ b/src/vars/menu.lua
@@ -52,6 +52,8 @@ DEFAULT_STARTING_MENU_VARS = {
         copiedSVs = {},
         copiedSSFs = {},
         copiedBMs = {},
+        tryAlign = true,
+        alignWindow = 3,
     },
     directSV = {
         selectableIndex = 1,


### PR DESCRIPTION
mrrow
the reason i like save hitObjects in a variable and pass it to tryAlignToHitObjects is that using map.HitObjects is very slow